### PR TITLE
feat: Don't serve hidden assets

### DIFF
--- a/assets.ts
+++ b/assets.ts
@@ -3,6 +3,7 @@
 import {
   type ConnInfo,
   type Handler,
+  basename,
   joinPath,
   serveFile,
   fromFileUrl,
@@ -30,6 +31,11 @@ export function assets(dir?: string): Handler {
   ) => {
     const ctx = useContext(req, conn);
     const path = joinPath(assetsDir, ctx.path);
+
+    const base = basename(path);
+    if (base.startsWith("_") ||  base.startsWith(".")) {
+      throw new Deno.errors.NotFound();
+    }
     
     const stat1 = await stat(path);
     if (stat1 && stat1.isFile && path.endsWith(".html")) {

--- a/deps.ts
+++ b/deps.ts
@@ -13,4 +13,5 @@ export {
 export {
   join as joinPath,
   fromFileUrl,
+  basename,
 } from "https://deno.land/std@0.163.0/path/mod.ts";

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2022 Connor Speers. All rights reserved. MIT License.
 
 import { assertEquals, assertRejects } from "./test_deps.ts";
-import { assets } from "./assets.ts";
-import type { ConnInfo } from "./deps.ts";
-import { router } from "./router.ts";
+import { assets } from "../assets.ts";
+import type { ConnInfo } from "../deps.ts";
+import { router } from "../router.ts";
 
 const connInfo: ConnInfo = {
   localAddr: {

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2022 Connor Speers. All rights reserved. MIT License.
 
 import { assertEquals, assertRejects } from "./test_deps.ts";
-import { assets } from "../assets.ts";
-import type { ConnInfo } from "../deps.ts";
-import { router } from "../router.ts";
+import { assets } from "./assets.ts";
+import type { ConnInfo } from "./deps.ts";
+import { router } from "./router.ts";
 
 const connInfo: ConnInfo = {
   localAddr: {
@@ -72,3 +72,25 @@ Deno.test("works inside a router", async () => {
   const res = await app2(req, connInfo);
   assertEquals(await res.text(), "index\n");
 });
+
+Deno.test(
+  "404 for requests to files that start with an underscore",
+  async () => {
+    const req = new Request("http://_/_hidden.txt");
+    await assertRejects(
+      async () => await app(req, connInfo),
+      Deno.errors.NotFound,
+    );
+  },
+);
+
+Deno.test(
+  "404 for requests to files that start with a period",
+  async () => {
+    const req = new Request("http://_/.hidden.txt");
+    await assertRejects(
+      async () => await app(req, connInfo),
+      Deno.errors.NotFound,
+    );
+  },
+);


### PR DESCRIPTION
Hidden assets, i.e. those with filenames that start with either a period or an underscore, shouldn't be served.