### PR TITLE
fix: index redirects

### DIFF
--- a/assets.ts
+++ b/assets.ts
@@ -33,7 +33,7 @@ export function assets(dir?: string): Handler {
     const path = joinPath(assetsDir, ctx.path);
 
     const base = basename(path);
-    if (base.startsWith("_") ||  base.startsWith(".")) {
+    if (base.startsWith(".")) {
       throw new Deno.errors.NotFound();
     }
     

--- a/assets.ts
+++ b/assets.ts
@@ -31,22 +31,33 @@ export function assets(dir?: string): Handler {
   ) => {
     const ctx = useContext(req, conn);
     const path = joinPath(assetsDir, ctx.path);
+    const base = basename(ctx.url.pathname);
 
-    const base = basename(path);
     if (base.startsWith(".")) {
       throw new Deno.errors.NotFound();
     }
     
     const stat1 = await stat(path);
-    if (stat1 && stat1.isFile && path.endsWith(".html")) {
+    if (stat1 && stat1.isFile && base === "index.html") {
+      const url = new URL(ctx.url);
+      url.pathname = joinPath(url.pathname, "..");
+      return Response.redirect(url.href);
+    }
+    if (stat1 && stat1.isFile && base.endsWith(".html")) {
       const url = new URL(ctx.url);
       url.pathname = url.pathname.slice(0, -5);
       return Response.redirect(url.href);
-    } else if (stat1 && stat1.isFile) {
+    }
+    if (stat1 && stat1.isFile) {
       return await serveFile(req, path);
     }
 
     const stat2 = await stat(path + ".html");
+    if (stat2 && stat2.isFile && base === "index") {
+      const url = new URL(ctx.url);
+      url.pathname = joinPath(url.pathname, "..");
+      return Response.redirect(url.href);
+    }
     if (stat2 && stat2.isFile) {
       return await serveFile(req, path + ".html");
     }

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -73,14 +73,6 @@ Deno.test("works inside a router", async () => {
   assertEquals(await res.text(), "index\n");
 });
 
-// Deno.test("404 for files that start with an underscore", async () => {
-//   const req = new Request("http://_/_hidden.txt");
-//   await assertRejects(
-//     async () => await app(req, connInfo),
-//     Deno.errors.NotFound,
-//   );
-// });
-
 Deno.test("404 for files that start with a period", async () => {
   const req = new Request("http://_/.hidden.txt");
   await assertRejects(

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -73,24 +73,36 @@ Deno.test("works inside a router", async () => {
   assertEquals(await res.text(), "index\n");
 });
 
-Deno.test(
-  "404 for requests to files that start with an underscore",
-  async () => {
-    const req = new Request("http://_/_hidden.txt");
-    await assertRejects(
-      async () => await app(req, connInfo),
-      Deno.errors.NotFound,
-    );
-  },
-);
+Deno.test("404 for files that start with an underscore", async () => {
+  const req = new Request("http://_/_hidden.txt");
+  await assertRejects(
+    async () => await app(req, connInfo),
+    Deno.errors.NotFound,
+  );
+});
 
-Deno.test(
-  "404 for requests to files that start with a period",
-  async () => {
-    const req = new Request("http://_/.hidden.txt");
-    await assertRejects(
-      async () => await app(req, connInfo),
-      Deno.errors.NotFound,
-    );
-  },
-);
+Deno.test("404 for files that start with a period", async () => {
+  const req = new Request("http://_/.hidden.txt");
+  await assertRejects(
+    async () => await app(req, connInfo),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("redirects existing *.html requests to URL w/o ext", async () => {
+  const req = new Request("http://_/not-nested.html");
+  const res = await app(req, connInfo);
+  assertEquals(res.status, 302);
+  assertEquals(res.headers.get("location"), "http://_/not-nested");
+});
+
+Deno.test("redirects /**/index(.html) to /**/", async () => {
+  const req = new Request("http://_/index.html");
+  const res = await app(req, connInfo);
+  assertEquals(res.status, 302);
+  assertEquals(res.headers.get("location"), "http://_/");
+  const req2 = new Request("http://_/index");
+  const res2 = await app(req2, connInfo);
+  assertEquals(res2.status, 302);
+  assertEquals(res2.headers.get("location"), "http://_/");
+});

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -73,13 +73,13 @@ Deno.test("works inside a router", async () => {
   assertEquals(await res.text(), "index\n");
 });
 
-Deno.test("404 for files that start with an underscore", async () => {
-  const req = new Request("http://_/_hidden.txt");
-  await assertRejects(
-    async () => await app(req, connInfo),
-    Deno.errors.NotFound,
-  );
-});
+// Deno.test("404 for files that start with an underscore", async () => {
+//   const req = new Request("http://_/_hidden.txt");
+//   await assertRejects(
+//     async () => await app(req, connInfo),
+//     Deno.errors.NotFound,
+//   );
+// });
 
 Deno.test("404 for files that start with a period", async () => {
   const req = new Request("http://_/.hidden.txt");


### PR DESCRIPTION
There's some problems with how requests to index files get redirected. Right now they trigger a double hop, but only one is necessary.