### PR TITLE
feat: Objects no longer allowed on router

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -14,7 +14,7 @@ export type RouterHandler = (
 
 /** The shape of a router, mapping route path to its corresponding handler. */
 export interface RouterShape {
-  [x: string]: RouterHandler | RouterHandler[] | RouterShape | null;
+  [x: string]: RouterHandler | RouterHandler[] | null;
 }
 
 /** Routes requests between multiple handlers based on request path. */
@@ -35,12 +35,6 @@ export function router<Shape extends RouterShape>(
     let handlers = shape[k]!;
     if (typeof handlers === "function") {
       handlers = [handlers];
-    } else if (
-      handlers &&
-      !Array.isArray(handlers) &&
-      typeof handlers === "object"
-    ) {
-      handlers = [router(handlers)];
     }
     routes.set(k.split("/").map(decodeURIComponent), handlers);
   }

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -73,14 +73,6 @@ Deno.test("works inside a router", async () => {
   assertEquals(await res.text(), "index\n");
 });
 
-// Deno.test("404 for files that start with an underscore", async () => {
-//   const req = new Request("http://_/_hidden.txt");
-//   await assertRejects(
-//     async () => await app(req, connInfo),
-//     Deno.errors.NotFound,
-//   );
-// });
-
 Deno.test("404 for files that start with a period", async () => {
   const req = new Request("http://_/.hidden.txt");
   await assertRejects(

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -73,24 +73,36 @@ Deno.test("works inside a router", async () => {
   assertEquals(await res.text(), "index\n");
 });
 
-Deno.test(
-  "404 for requests to files that start with an underscore",
-  async () => {
-    const req = new Request("http://_/_hidden.txt");
-    await assertRejects(
-      async () => await app(req, connInfo),
-      Deno.errors.NotFound,
-    );
-  },
-);
+Deno.test("404 for files that start with an underscore", async () => {
+  const req = new Request("http://_/_hidden.txt");
+  await assertRejects(
+    async () => await app(req, connInfo),
+    Deno.errors.NotFound,
+  );
+});
 
-Deno.test(
-  "404 for requests to files that start with a period",
-  async () => {
-    const req = new Request("http://_/.hidden.txt");
-    await assertRejects(
-      async () => await app(req, connInfo),
-      Deno.errors.NotFound,
-    );
-  },
-);
+Deno.test("404 for files that start with a period", async () => {
+  const req = new Request("http://_/.hidden.txt");
+  await assertRejects(
+    async () => await app(req, connInfo),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("redirects existing *.html requests to URL w/o ext", async () => {
+  const req = new Request("http://_/not-nested.html");
+  const res = await app(req, connInfo);
+  assertEquals(res.status, 302);
+  assertEquals(res.headers.get("location"), "http://_/not-nested");
+});
+
+Deno.test("redirects /**/index(.html) to /**/", async () => {
+  const req = new Request("http://_/index.html");
+  const res = await app(req, connInfo);
+  assertEquals(res.status, 302);
+  assertEquals(res.headers.get("location"), "http://_/");
+  const req2 = new Request("http://_/index");
+  const res2 = await app(req2, connInfo);
+  assertEquals(res2.status, 302);
+  assertEquals(res2.headers.get("location"), "http://_/");
+});

--- a/test/assets_test.ts
+++ b/test/assets_test.ts
@@ -73,13 +73,13 @@ Deno.test("works inside a router", async () => {
   assertEquals(await res.text(), "index\n");
 });
 
-Deno.test("404 for files that start with an underscore", async () => {
-  const req = new Request("http://_/_hidden.txt");
-  await assertRejects(
-    async () => await app(req, connInfo),
-    Deno.errors.NotFound,
-  );
-});
+// Deno.test("404 for files that start with an underscore", async () => {
+//   const req = new Request("http://_/_hidden.txt");
+//   await assertRejects(
+//     async () => await app(req, connInfo),
+//     Deno.errors.NotFound,
+//   );
+// });
 
 Deno.test("404 for files that start with a period", async () => {
   const req = new Request("http://_/.hidden.txt");

--- a/test/router_test.ts
+++ b/test/router_test.ts
@@ -291,20 +291,3 @@ Deno.test("unrouted/routed path on context", async () => {
   const res3 = await testRouter(req3, connInfo);
   assertEquals(await res3.text(), "/index|/");
 });
-
-Deno.test("nested objects become nested routers", async () => {
-  const testRouter = router({
-    "a/*": {
-      "b": () => new Response("yep"),
-      "*": () => new Response("yep yep"),
-    },
-  });
-
-  const req1 = new Request("https://_/a/b");
-  const res1 = await testRouter(req1, connInfo);
-  assertEquals(await res1.text(), "yep");
-
-  const req2 = new Request("https://_/a/b/c");
-  const res2 = await testRouter(req2, connInfo);
-  assertEquals(await res2.text(), "yep yep");
-});


### PR DESCRIPTION
I'm going back on the idea to allow nested router shapes because it would mean all nested route shapes would need to be "something/*" routes. Which is a weird thing to note in docs, better to just remove the ability to do that.