### PR TITLE
feat: use `.js.ts` as bundle extension instead of just `.js`

### DIFF
--- a/prep.ts
+++ b/prep.ts
@@ -24,7 +24,8 @@ export interface PrepOptions {
  * files, recursively.
  *
  * This function returns after the initial bundling. Then, the source files are
- * watched for changes which will trigger a re-bundle.
+ * watched for changes which will trigger a re-bundle, unless the `watch` option
+ * is explicitly `false`.
  *
  * The output file paths are equal to the input file paths but with a ".js"
  * extension instead of a ".ts" extension. This WILL overwrite old JavaScript

--- a/prep.ts
+++ b/prep.ts
@@ -76,7 +76,7 @@ async function process(input: string, watch?: boolean) {
     return;
   }
   processing.add(input);
-  const output = input.slice(0, -3) + ".js";
+  const output = input + ".js";
 
   try {
     const stat = await Deno.stat(input);

--- a/test/prep_test.ts
+++ b/test/prep_test.ts
@@ -6,11 +6,11 @@ import { fromFileUrl } from "../deps.ts";
 
 Deno.test("basic test", async () => {
   const i = import.meta.resolve("./public");
-  const o1 = fromFileUrl(import.meta.resolve("./public/bundle1.js"));
-  const o2 = fromFileUrl(import.meta.resolve("./public/bundle2.js"));
-  const o3 = fromFileUrl(import.meta.resolve("./public/nested/bundle3.js"));
-  const o4 = fromFileUrl(import.meta.resolve("./public/_bundle4.js"));
-  const o5 = fromFileUrl(import.meta.resolve("./public/.bundle5.js"));
+  const o1 = fromFileUrl(import.meta.resolve("./public/bundle1.ts.js"));
+  const o2 = fromFileUrl(import.meta.resolve("./public/bundle2.ts.js"));
+  const o3 = fromFileUrl(import.meta.resolve("./public/nested/bundle3.ts.js"));
+  const o4 = fromFileUrl(import.meta.resolve("./public/_bundle4.ts.js"));
+  const o5 = fromFileUrl(import.meta.resolve("./public/.bundle5.ts.js"));
   await prep({
     dir: i,
     watch: false,


### PR DESCRIPTION
To differentiate bundles from raw JavaScript files, use the `.ts.js` extension instead of replacing `.ts` with `.js` in `prep()`.