### PR TITLE
feat: dom

### DIFF
--- a/dom.ts
+++ b/dom.ts
@@ -1,0 +1,8 @@
+// Copyright 2022 Connor Speers. All rights reserved. MIT License.
+// This module is browser-only.
+
+/// <reference no-default-lib="true" />
+/// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
+/// <reference lib="dom.asynciterable" />
+/// <reference lib="esnext" />


### PR DESCRIPTION
The default TypeScript config in Deno isn't conducive to writing TypeScript for the browser. However, Deno respects TypeScript's [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html), which makes it easier to activate browser libraries selectively.

I added the `dom.ts` file which includes all the basic browser directives. When imported, the IDE switches the TS libraries to browser mode. Very useful for prepared TS bundles.