### PR TITLE
fix: prep deps bug

### DIFF
--- a/prep.ts
+++ b/prep.ts
@@ -103,7 +103,7 @@ async function process(input: string, watch?: boolean) {
         try {
           await Deno.remove(output);
         } catch (err) {
-          console.warn(err);
+          console.warn(`[${output}]`, err);
         }
       }
     } catch {
@@ -113,7 +113,7 @@ async function process(input: string, watch?: boolean) {
     return;
   }
 
-  let deps = [input];
+  let deps: string[] = [];
   try {
     deps = await customGraph(inputUrl);
     const code = await customBundle(input);
@@ -123,7 +123,10 @@ async function process(input: string, watch?: boolean) {
       processing.delete(input);
       throw err;
     }
-    console.warn(err);
+    if (!deps.length) {
+      deps = [input];
+    }
+    console.warn(`[${input}]`, err);
   }
 
   // The first conditional is needed in case stopPrep was called before the


### PR DESCRIPTION
There was a bug where invalid typescript would result in an empty graph, and the input file would never get watched for updates as a result. Any updates made to the buggy file would be ignored and no new cache would be generated.

The fix was to check if the graph is empty and add the input file whenever there's a bundling error.